### PR TITLE
refactor(participant-create): Moved participant create to its own endpoint

### DIFF
--- a/webapi/FFischbach.Events.API/AutoMapper/AutoMapperProfile.cs
+++ b/webapi/FFischbach.Events.API/AutoMapper/AutoMapperProfile.cs
@@ -48,9 +48,15 @@ namespace FFischbach.Events.API.AutoMapper
                 .ForMember(x => x.Participants, o => o.MapFrom(x => x.Participants!.Where(y => !y.IsContact).ToList()));
 
             // Participant.
-            CreateMap<ParticipantCreateModel, Participant>()
+            CreateMap<ParticipantInputModel, Participant>()
                 .ForMember(x => x.CreatedAt, o => o.MapFrom(x => DateTime.UtcNow))
                 .ForMember(x => x.EncryptedData, o => o.MapFrom<ParticipantEncryptedDataResolver>()); // Requires "PublicKey" as passed in Items dict.
+
+            CreateMap<ParticipantCreateModel, Participant>()
+                .IncludeBase<ParticipantInputModel, Participant>();
+
+            CreateMap<ParticipantGroupCreateModel, Participant>()
+                .IncludeBase<ParticipantInputModel, Participant>();
 
             CreateMap<ParticipantUpdateModel, Participant>();
 

--- a/webapi/FFischbach.Events.API/AutoMapper/ParticipantEncryptedDataResolver.cs
+++ b/webapi/FFischbach.Events.API/AutoMapper/ParticipantEncryptedDataResolver.cs
@@ -7,9 +7,9 @@ using System.Text;
 
 namespace FFischbach.Events.API.AutoMapper
 {
-    public class ParticipantEncryptedDataResolver : IValueResolver<ParticipantCreateModel, Participant, byte[]>
+    public class ParticipantEncryptedDataResolver : IValueResolver<ParticipantInputModel, Participant, byte[]>
     {
-        public byte[] Resolve(ParticipantCreateModel source, Participant destination, byte[] destMember, ResolutionContext context)
+        public byte[] Resolve(ParticipantInputModel source, Participant destination, byte[] destMember, ResolutionContext context)
         {
             // Get public key from context.
             string publicKey = context.Items["PublicKey"] as string ?? throw new Exception("Missing public key on participant encryption.");

--- a/webapi/FFischbach.Events.API/Controllers/GroupsController.cs
+++ b/webapi/FFischbach.Events.API/Controllers/GroupsController.cs
@@ -16,10 +16,9 @@ namespace FFischbach.Events.API.Controllers
     [RequiredScope(RequiredScopesConfigurationKey = "AzureAd:Scopes")]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-    public class GroupsController(IGroupService groupService, IParticipantService participantService) : ControllerBase
+    public class GroupsController(IGroupService groupService) : ControllerBase
     {
         private IGroupService GroupService { get; set; } = groupService;
-        private IParticipantService ParticipantService { get; set; } = participantService;
 
         /// <summary>
         /// Creates a group.
@@ -133,36 +132,6 @@ namespace FFischbach.Events.API.Controllers
                 return Problem(detail: ex.Detail, title: ex.Message, statusCode: ex.StatusCode);
             }
             return NoContent();
-        }
-
-        /// <summary>
-        /// Adds a participant to an event.
-        /// </summary>
-        /// <param name="id">Id of the group</param>
-        /// <param name="participant">The participant to be created</param>
-        /// <param name="isContact">Value indicating if new participant should replace the current contact</param>
-        /// 
-        [HttpPost("{id}/Participant")]
-        [ProducesResponseType(StatusCodes.Status403Forbidden)]
-        [ProducesResponseType(typeof(GroupDetailOutputModel), StatusCodes.Status200OK)]
-        public async Task<ActionResult<GroupDetailOutputModel>> AddParticipant([Required] int? id, [FromBody, Required] ParticipantCreateModel? participant, [FromQuery] bool isContact = false)
-        {
-            GroupDetailOutputModel returnValue;
-            try
-            {
-                // Validate.
-                if (!ModelState.IsValid)
-                {
-                    return BadRequest(ModelState);
-                }
-
-                returnValue = await ParticipantService.AddParticipantAsync(User, (int)id!, participant!, isContact);
-            }
-            catch (CustomException ex)
-            {
-                return Problem(detail: ex.Detail, title: ex.Message, statusCode: ex.StatusCode);
-            }
-            return Ok(returnValue);
         }
     }
 }

--- a/webapi/FFischbach.Events.API/Controllers/ParticipantsController.cs
+++ b/webapi/FFischbach.Events.API/Controllers/ParticipantsController.cs
@@ -1,0 +1,53 @@
+﻿using FFischbach.Events.API.Helpers;
+using FFischbach.Events.API.Models.InputModels;
+using FFischbach.Events.API.Models.OutputModels;
+using FFischbach.Events.API.Services.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Identity.Web.Resource;
+using System.ComponentModel.DataAnnotations;
+
+namespace FFischbach.Events.API.Controllers
+{
+    [Authorize]
+    [ApiController]
+    [Route("[controller]")]
+    [Produces("application/json")]
+    [RequiredScope(RequiredScopesConfigurationKey = "AzureAd:Scopes")]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public class ParticipantsController(IParticipantService participantService) : ControllerBase
+    {
+        private IParticipantService ParticipantService { get; } = participantService;
+
+        /// <summary>
+        /// Creates a participant.
+        /// </summary>
+        /// <param name="participant">The participant to be created</param>
+        /// <param name="isContact">Value indicating if the new participant should replace the current contact of the group</param>
+        /// <returns></returns>
+        [HttpPost]
+        [AllowAnonymous]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ParticipantOutputModel), StatusCodes.Status200OK)]
+        public async Task<IActionResult> Post([FromBody, Required] ParticipantCreateModel? participant, [FromQuery] bool isContact = false)
+        {
+            ParticipantOutputModel returnValue;
+            try
+            {
+                // Validate.
+                if (!ModelState.IsValid)
+                {
+                    return BadRequest(ModelState);
+                }
+
+                returnValue = await ParticipantService.CreateParticipantAsync(User, participant!, isContact);
+            }
+            catch (CustomException ex)
+            {
+                return Problem(detail: ex.Detail, title: ex.Message, statusCode: ex.StatusCode);
+            }
+            return Ok(returnValue);
+        }
+    }
+}

--- a/webapi/FFischbach.Events.API/Data/DatabaseContext.cs
+++ b/webapi/FFischbach.Events.API/Data/DatabaseContext.cs
@@ -169,7 +169,7 @@ namespace FFischbach.Events.API.Data
                 c.Property(x => x.CreatedAt)
                     .IsRequired();
             });
-            
+
             base.OnModelCreating(modelBuilder);
         }
     }

--- a/webapi/FFischbach.Events.API/Models/InputModels/CategoryCreateModel.cs
+++ b/webapi/FFischbach.Events.API/Models/InputModels/CategoryCreateModel.cs
@@ -12,7 +12,7 @@ namespace FFischbach.Events.API.Models.InputModels
         /// </summary>
         [Required, StringLength(255)]
         public string? Name { get; set; }
-        
+
         /// <summary>
         /// Date from where sign up is possible. Leave empty if you don't want to restrict this.
         /// </summary>

--- a/webapi/FFischbach.Events.API/Models/InputModels/GroupCreateModel.cs
+++ b/webapi/FFischbach.Events.API/Models/InputModels/GroupCreateModel.cs
@@ -29,12 +29,12 @@ namespace FFischbach.Events.API.Models.InputModels
         /// Contact participant.
         /// </summary>
         [Required]
-        public ParticipantCreateModel? Contact { get; set; }
+        public ParticipantGroupCreateModel? Contact { get; set; }
 
         /// <summary>
         /// List of other participants. Do not include the contact here.
         /// </summary>
         [Required, MinLength(0)]
-        public List<ParticipantCreateModel>? Participants { get; set; }
+        public List<ParticipantGroupCreateModel>? Participants { get; set; }
     }
 }

--- a/webapi/FFischbach.Events.API/Models/InputModels/ParticipantCreateModel.cs
+++ b/webapi/FFischbach.Events.API/Models/InputModels/ParticipantCreateModel.cs
@@ -1,36 +1,16 @@
 ﻿using System.ComponentModel.DataAnnotations;
-using System.Text.Json.Serialization;
 
 namespace FFischbach.Events.API.Models.InputModels
 {
     /// <summary>
     /// Participant create model.
     /// </summary>
-    public class ParticipantCreateModel
+    public class ParticipantCreateModel : ParticipantInputModel
     {
         /// <summary>
-        /// Email adress, only needed on contact.
-        /// </summary>
-        [EmailAddress]
-        public string? Email { get; set; }
-
-        /// <summary>
-        /// First name.
+        /// Id of the group.
         /// </summary>
         [Required]
-        public string? FirstName { get; set; }
-
-        /// <summary>
-        /// Last name.
-        /// </summary>
-        [Required]
-        public string? LastName { get; set; }
-
-        /// <summary>
-        /// Birth date.
-        /// </summary>
-        /// <example>2000-12-31</example>
-        [Required]
-        public DateOnly? BirthDate { get; set; }
+        public int? GroupId { get; set; }
     }
 }

--- a/webapi/FFischbach.Events.API/Models/InputModels/ParticipantGroupCreateModel.cs
+++ b/webapi/FFischbach.Events.API/Models/InputModels/ParticipantGroupCreateModel.cs
@@ -1,0 +1,9 @@
+﻿namespace FFischbach.Events.API.Models.InputModels
+{
+    /// <summary>
+    /// Participant create model when passed inside of a group.
+    /// </summary>
+    public class ParticipantGroupCreateModel : ParticipantInputModel
+    {
+    }
+}

--- a/webapi/FFischbach.Events.API/Models/InputModels/ParticipantInputModel.cs
+++ b/webapi/FFischbach.Events.API/Models/InputModels/ParticipantInputModel.cs
@@ -1,0 +1,35 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace FFischbach.Events.API.Models.InputModels
+{
+    /// <summary>
+    /// Base participant create model.
+    /// </summary>
+    public class ParticipantInputModel
+    {
+        /// <summary>
+        /// Email adress, only needed on contact.
+        /// </summary>
+        [EmailAddress]
+        public string? Email { get; set; }
+
+        /// <summary>
+        /// First name.
+        /// </summary>
+        [Required]
+        public string? FirstName { get; set; }
+
+        /// <summary>
+        /// Last name.
+        /// </summary>
+        [Required]
+        public string? LastName { get; set; }
+
+        /// <summary>
+        /// Birth date.
+        /// </summary>
+        /// <example>2000-12-31</example>
+        [Required]
+        public DateOnly? BirthDate { get; set; }
+    }
+}

--- a/webapi/FFischbach.Events.API/Models/Participant.cs
+++ b/webapi/FFischbach.Events.API/Models/Participant.cs
@@ -3,7 +3,7 @@
     public class Participant
     {
         public int Id { get; set; }
-        public required byte[] EncryptedData { get;set; }
+        public required byte[] EncryptedData { get; set; }
         public bool IsContact { get; set; }
         public bool? VIP { get; set; }
         public int GroupId { get; set; }

--- a/webapi/FFischbach.Events.API/Services/EventService.cs
+++ b/webapi/FFischbach.Events.API/Services/EventService.cs
@@ -235,7 +235,7 @@ namespace FFischbach.Events.API.Services
 
                 // Get event from the database.
                 Event? dbEvent = await DatabaseContext.Events
-                                        .Include (x => x.Groups!)
+                                        .Include(x => x.Groups!)
                                             .ThenInclude(x => x.Participants)
                                         .Include(x => x.EventManagers!)
                                             .ThenInclude(x => x.Manager)

--- a/webapi/FFischbach.Events.API/Services/Interfaces/IParticipantService.cs
+++ b/webapi/FFischbach.Events.API/Services/Interfaces/IParticipantService.cs
@@ -8,14 +8,13 @@ namespace FFischbach.Events.API.Services.Interfaces
     public interface IParticipantService
     {
         /// <summary>
-        /// Adds the given <paramref name="participant"/> to the group with id <paramref name="groupId"/>.
+        /// Adds the given <paramref name="participant"/>.
         /// </summary>
         /// <param name="user"></param>
-        /// <param name="groupId"></param>
         /// <param name="participant"></param>
         /// <param name="isContact">Indicates whether participant should be the groups contact.</param>
-        /// <returns>The updated state of the group.</returns>
+        /// <returns>The created participant.</returns>
         /// <exception cref="CustomException"></exception>
-        Task<GroupDetailOutputModel> AddParticipantAsync(ClaimsPrincipal user, int groupId, ParticipantCreateModel participant, bool isContact);
+        Task<ParticipantOutputModel> CreateParticipantAsync(ClaimsPrincipal user, ParticipantCreateModel participant, bool isContact);
     }
 }

--- a/webapi/FFischbach.Events.API/Services/ParticipantService.cs
+++ b/webapi/FFischbach.Events.API/Services/ParticipantService.cs
@@ -10,17 +10,16 @@ using System.Security.Claims;
 
 namespace FFischbach.Events.API.Services
 {
-    public class ParticipantService(ILogger<ParticipantService> logger, IMapper mapper, DatabaseContext databaseContext, IUserService userService, IGroupService groupService) : IParticipantService
+    public class ParticipantService(ILogger<ParticipantService> logger, IMapper mapper, DatabaseContext databaseContext, IUserService userService) : IParticipantService
     {
         private ILogger<ParticipantService> Logger { get; } = logger;
         private IMapper Mapper { get; } = mapper;
         private DatabaseContext DatabaseContext { get; } = databaseContext;
         private IUserService UserService { get; } = userService;
-        private IGroupService GroupService { get; } = groupService;
 
-        public async Task<GroupDetailOutputModel> AddParticipantAsync(ClaimsPrincipal user, int groupId, ParticipantCreateModel participant, bool isContact)
+        public async Task<ParticipantOutputModel> CreateParticipantAsync(ClaimsPrincipal user, ParticipantCreateModel participant, bool isContact)
         {
-            GroupDetailOutputModel returnValue;
+            ParticipantOutputModel returnValue;
             try
             {
                 // Get user display name.
@@ -31,7 +30,7 @@ namespace FFischbach.Events.API.Services
                                         .Include(x => x.Event!)
                                         .ThenInclude(x => x.EventManagers!)
                                             .ThenInclude(x => x.Manager)
-                                    .FirstOrDefaultAsync(x => x.Id == groupId);
+                                    .FirstOrDefaultAsync(x => x.Id == participant.GroupId);
 
                 // Check db response.
                 if (dbGroup == null)
@@ -54,7 +53,7 @@ namespace FFischbach.Events.API.Services
                 if (isContact)
                 {
                     // Get the current contact.
-                    Participant? currentContact = await DatabaseContext.Participants.FirstOrDefaultAsync(x => x.GroupId == groupId && x.IsContact);
+                    Participant? currentContact = await DatabaseContext.Participants.FirstOrDefaultAsync(x => x.GroupId == participant.GroupId && x.IsContact);
 
                     if (currentContact != null)
                     {
@@ -73,17 +72,17 @@ namespace FFischbach.Events.API.Services
                 DatabaseContext.Participants.Add(dbParticipant);
                 await DatabaseContext.SaveChangesAsync();
 
-                // Get the new state of the group.
-                returnValue = await GroupService.GetGroupAsync(user, groupId);
+                // Map the participant.
+                returnValue = Mapper.Map<ParticipantOutputModel>(dbParticipant);
             }
             catch (CustomException ex)
             {
-                Logger.LogWarning(ex, "Failed to add participant to the group '{id}'.", groupId);
+                Logger.LogWarning(ex, "Failed to add participant to the group '{id}'.", participant.GroupId);
                 throw;
             }
             catch (Exception ex)
             {
-                Logger.LogError(ex, "Failed to add participant to the group '{id}'.", groupId);
+                Logger.LogError(ex, "Failed to add participant to the group '{id}'.", participant.GroupId);
                 throw new CustomException("Unerwarteter Fehler beim Hinzufügen eines Teilnehmers.", ex);
             }
             return returnValue;

--- a/webapi/FFischbach.Events.API/Services/ParticipantService.cs
+++ b/webapi/FFischbach.Events.API/Services/ParticipantService.cs
@@ -52,6 +52,12 @@ namespace FFischbach.Events.API.Services
                 // Check if the contact should be changed.
                 if (isContact)
                 {
+                    // Check if the email is given.
+                    if (string.IsNullOrEmpty(participant.Email))
+                    {
+                        throw new CustomException("Beim Erstellen eines neuen Kontakts muss eine Email mitgegeben werden.", statusCode: StatusCodes.Status400BadRequest);
+                    }
+
                     // Get the current contact.
                     Participant? currentContact = await DatabaseContext.Participants.FirstOrDefaultAsync(x => x.GroupId == participant.GroupId && x.IsContact);
 


### PR DESCRIPTION
- New input model for participant create to have a group id in there
- New base model for both participant input models to remain with one single automapper resolver
- Ran dotnet format