### PR TITLE
feat(email): Implemented email sending in the backend

### DIFF
--- a/webapi/FFischbach.Events.API/AutoMapper/AutoMapperProfile.cs
+++ b/webapi/FFischbach.Events.API/AutoMapper/AutoMapperProfile.cs
@@ -20,7 +20,9 @@ namespace FFischbach.Events.API.AutoMapper
             // Event.
             CreateMap<EventCreateModel, Event>()
                 .ForMember(x => x.Completed, o => o.MapFrom(x => false))
-                .ForMember(x => x.CreatedAt, o => o.MapFrom(x => DateTime.UtcNow));
+                .ForMember(x => x.CreatedAt, o => o.MapFrom(x => DateTime.UtcNow))
+                .ForMember(x => x.RegistrationEmailContent, o => o.MapFrom(x => DefaultRegistrationEmailContent))
+                .ForMember(x => x.ApprovalEmailContent, o => o.MapFrom(x => DefaultApprovalEmailContent));
 
             CreateMap<EventUpdateModel, Event>();
 
@@ -62,5 +64,68 @@ namespace FFischbach.Events.API.AutoMapper
 
             CreateMap<Participant, ParticipantOutputModel>();
         }
+
+        private const string DefaultRegistrationEmailContent = @"
+<p>Hallo [[ContactFirstName]],</p>
+
+<p>
+    die Anmeldung deiner Gruppe <strong>[[GroupName]]</strong> für die RAUP ist bei uns eingegangen.
+</p>
+
+<p>
+    Sobald die Anmeldung genehmigt wurde erhältst du von uns eine weitere Mail.
+</p>
+
+<p>Folgende Teilnehmer wurden angemeldet:</p>
+
+[[ParticipantsTable]]
+
+<p>Solltest du noch Rückfragen haben, antworte gerne auf diese Mail.</p>
+
+<p style='margin-top: 30px;'>
+    Viele Grüße<br/>
+    <strong>RAUP-Orgateam der Feuerwehr Fischbach</strong>
+</p>
+";
+
+        private const string DefaultApprovalEmailContent = @"
+<p>Hallo [[ContactFirstName]],</p>
+
+<p>
+    die Anmeldung deiner Gruppe <strong>[[GroupName]]</strong> für die RAUP wurde genehmigt.
+</p>
+
+<p>
+    Die Tickets können am <strong>05. Februar</strong> zwischen 
+    <strong>18:30 Uhr und 19:30 Uhr</strong> im <strong>Fischbacher Gerätehaus</strong> 
+    abgeholt werden.
+</p>
+
+<p>Bitte weist eure Freunde nochmal auf folgende Hinweise hin, damit es am Veranstaltungstag zu keinen Problemen kommt:</p>
+
+<ul style='line-height: 1.5;'>
+    <li>Einlass wird nur mit einer personalisierten Eintrittskarte gewährt.</li>
+    <li>Bei Einlass ist ggf. ein Ausweisdokument vorzulegen.</li>
+    <li>Die Eintrittskarte berechtigt nicht verbindlich bzw. nicht zum sofortigen Einlass zur Veranstaltung.</li>
+    <li>Am Eingang kann es, je nach Auslastung im Veranstaltungsraum, zu Wartezeiten kommen.</li>
+    <li>Stark alkoholisierten Personen wird kein Einlass gewährt.</li>
+    <li>Mitgebrachte Getränke müssen am Eingang abgegeben werden.</li>
+    <li>Verkauf von Getränken und Speisen nur gegen Wertmarken.</li>
+    <li>Wir halten uns an das Gesetz zum Schutz der Jugend in der Öffentlichkeit.</li>
+    <li>Wir übernehmen keine Haftung für Garderobe, Sachschäden oder Körperschäden.</li>
+</ul>
+
+<h3 style='margin-top: 25px;'>Gruppenübersicht</h3>
+
+<p>Folgende Teilnehmer wurden angemeldet:</p>
+
+[[ParticipantsTable]]
+
+<p>Solltest du noch Rückfragen haben, antworte gerne auf diese Mail.</p>
+
+<p style='margin-top: 30px;'>
+    Viele Grüße<br/>
+    <strong>RAUP-Orgateam der Feuerwehr Fischbach</strong>
+</p>";
     }
 }

--- a/webapi/FFischbach.Events.API/Controllers/EventsController.cs
+++ b/webapi/FFischbach.Events.API/Controllers/EventsController.cs
@@ -1,6 +1,7 @@
 ﻿using FFischbach.Events.API.Helpers;
 using FFischbach.Events.API.Models.InputModels;
 using FFischbach.Events.API.Models.OutputModels;
+using FFischbach.Events.API.Services;
 using FFischbach.Events.API.Services.Interfaces;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -48,6 +49,62 @@ namespace FFischbach.Events.API.Controllers
                 return Problem(detail: ex.Detail, title: ex.Message, statusCode: ex.StatusCode);
             }
             return CreatedAtAction(nameof(Get), new { id = returnValue.Id }, returnValue);
+        }
+
+        /// <summary>
+        /// Sends a test registration mail for the event to the current user.
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns></returns>
+        [HttpPost("{id}/SendTestRegistrationMail")]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> SendTestRegistrationMail([Required] string? id)
+        {
+            try
+            {
+                // Validate.
+                if (!ModelState.IsValid)
+                {
+                    return BadRequest(ModelState);
+                }
+
+                await EventService.SendTestRegistrationMail(User, id!);
+            }
+            catch (CustomException ex)
+            {
+                return Problem(detail: ex.Detail, title: ex.Message, statusCode: ex.StatusCode);
+            }
+            return NoContent();
+        }
+
+        /// <summary>
+        /// Sends a test approval mail for the event to the current user.
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns></returns>
+        [HttpPost("{id}/SendTestApprovalMail")]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> SendTestApprovalMail([Required] string? id)
+        {
+            try
+            {
+                // Validate.
+                if (!ModelState.IsValid)
+                {
+                    return BadRequest(ModelState);
+                }
+
+                await EventService.SendTestApprovalMail(User, id!);
+            }
+            catch (CustomException ex)
+            {
+                return Problem(detail: ex.Detail, title: ex.Message, statusCode: ex.StatusCode);
+            }
+            return NoContent();
         }
 
         /// <summary>

--- a/webapi/FFischbach.Events.API/Controllers/GroupsController.cs
+++ b/webapi/FFischbach.Events.API/Controllers/GroupsController.cs
@@ -48,6 +48,35 @@ namespace FFischbach.Events.API.Controllers
         }
 
         /// <summary>
+        /// Sends the approval email to the group's contact person.
+        /// </summary>
+        /// <param name="id"></param>
+        /// <param name="group">The group to be created</param>
+        /// <returns></returns>
+        [HttpPost("{id}/SendApproval")]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> SendApproval([Required] int? id, [FromBody, Required] GroupApprovalModel? group)
+        {
+            try
+            {
+                // Validate.
+                if (!ModelState.IsValid)
+                {
+                    return BadRequest(ModelState);
+                }
+
+                await GroupService.SendApprovalMailAsync(User, (int)id!, group!);
+            }
+            catch (CustomException ex)
+            {
+                return Problem(detail: ex.Detail, title: ex.Message, statusCode: ex.StatusCode);
+            }
+            return NoContent();
+        }
+
+        /// <summary>
         /// Gets a single group.
         /// </summary>
         /// <param name="id">Id of the group</param>

--- a/webapi/FFischbach.Events.API/FFischbach.Events.API.csproj
+++ b/webapi/FFischbach.Events.API/FFischbach.Events.API.csproj
@@ -16,23 +16,24 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="AutoMapper" Version="13.0.1" />
-		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.8" NoWarn="NU1605" />
-		<PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.8" NoWarn="NU1605" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.8" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.8">
+		<PackageReference Include="AutoMapper" Version="14.0.0" />
+		<PackageReference Include="MailKit" Version="4.14.1" />
+		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.*" NoWarn="NU1605" />
+		<PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.*" NoWarn="NU1605" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.*" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.*">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.8" />
-		<PackageReference Include="Microsoft.Identity.Web" Version="3.0.1" />
-		<PackageReference Include="Microsoft.Identity.Web.DownstreamApi" Version="3.0.1" />
-		<PackageReference Include="Microsoft.Identity.Web.UI" Version="3.0.1" />
-		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />
-		<PackageReference Include="Serilog.AspNetCore" Version="8.0.2" />
-		<PackageReference Include="Serilog.Sinks.Seq" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.*" />
+		<PackageReference Include="Microsoft.Identity.Web" Version="4.1.1" />
+		<PackageReference Include="Microsoft.Identity.Web.DownstreamApi" Version="4.1.1" />
+		<PackageReference Include="Microsoft.Identity.Web.UI" Version="4.1.1" />
+		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.*" />
+		<PackageReference Include="Serilog.AspNetCore" Version="8.0.*" />
+		<PackageReference Include="Serilog.Sinks.Seq" Version="8.0.*" />
 		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.0" />
 		<PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.7.0" />
 	</ItemGroup>

--- a/webapi/FFischbach.Events.API/Migrations/20251205232152_EmailContent.Designer.cs
+++ b/webapi/FFischbach.Events.API/Migrations/20251205232152_EmailContent.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FFischbach.Events.API.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FFischbach.Events.API.Migrations
 {
     [DbContext(typeof(DatabaseContext))]
-    partial class DatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20251205232152_EmailContent")]
+    partial class EmailContent
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/webapi/FFischbach.Events.API/Migrations/20251205232152_EmailContent.cs
+++ b/webapi/FFischbach.Events.API/Migrations/20251205232152_EmailContent.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FFischbach.Events.API.Migrations
+{
+    /// <inheritdoc />
+    public partial class EmailContent : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ApprovalEmailContent",
+                table: "Events",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "RegistrationEmailContent",
+                table: "Events",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ApprovalEmailContent",
+                table: "Events");
+
+            migrationBuilder.DropColumn(
+                name: "RegistrationEmailContent",
+                table: "Events");
+        }
+    }
+}

--- a/webapi/FFischbach.Events.API/Models/Event.cs
+++ b/webapi/FFischbach.Events.API/Models/Event.cs
@@ -8,6 +8,8 @@
         public bool Completed { get; set; }
         public required string PublicKey { get; set; }
         public required string EncryptedPrivateKey { get; set; }
+        public string? RegistrationEmailContent { get; set; }
+        public string? ApprovalEmailContent { get; set; }
         public List<Group>? Groups { get; set; }
         public List<EventManager>? EventManagers { get; set; }
         public List<Category>? Categories { get; set; }

--- a/webapi/FFischbach.Events.API/Models/InputModels/EventUpdateModel.cs
+++ b/webapi/FFischbach.Events.API/Models/InputModels/EventUpdateModel.cs
@@ -21,5 +21,17 @@ namespace FFischbach.Events.API.Models.InputModels
         /// </summary>
         [Required]
         public bool? Completed { get; set; }
+
+        /// <summary>
+        /// The contents of the registration mail.
+        /// The following placeholders can be used: [[ContactFirstName]] [[GroupName]] [[ParticipantsTable]].
+        /// </summary>
+        public string? RegistrationEmailContent { get; set; }
+
+        /// <summary>
+        /// The contents of the approval mail.
+        /// The following placeholders can be used: [[ContactFirstName]] [[GroupName]] [[ParticipantsTable]].
+        /// </summary>
+        public string? ApprovalEmailContent { get; set; }
     }
 }

--- a/webapi/FFischbach.Events.API/Models/InputModels/GroupApprovalModel.cs
+++ b/webapi/FFischbach.Events.API/Models/InputModels/GroupApprovalModel.cs
@@ -1,0 +1,28 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace FFischbach.Events.API.Models.InputModels
+{
+    /// <summary>
+    /// Group approval email model.
+    /// </summary>
+    public class GroupApprovalModel
+    {
+        /// <summary>
+        /// Name.
+        /// </summary>
+        [Required]
+        public string? Name { get; set; }
+
+        /// <summary>
+        /// Contact participant.
+        /// </summary>
+        [Required]
+        public ParticipantGroupApprovalModel? Contact { get; set; }
+
+        /// <summary>
+        /// List of other participants. Do not include the contact here.
+        /// </summary>
+        [Required, MinLength(0)]
+        public List<ParticipantGroupApprovalModel>? Participants { get; set; }
+    }
+}

--- a/webapi/FFischbach.Events.API/Models/InputModels/ParticipantGroupApprovalModel.cs
+++ b/webapi/FFischbach.Events.API/Models/InputModels/ParticipantGroupApprovalModel.cs
@@ -1,0 +1,10 @@
+﻿namespace FFischbach.Events.API.Models.InputModels
+{
+    public class ParticipantGroupApprovalModel : ParticipantInputModel
+    {
+        /// <summary>
+        /// VIP.
+        /// </summary>
+        public bool? VIP { get; set; }
+    }
+}

--- a/webapi/FFischbach.Events.API/Models/OutputModels/EventDetailOutputModel.cs
+++ b/webapi/FFischbach.Events.API/Models/OutputModels/EventDetailOutputModel.cs
@@ -46,6 +46,18 @@
         public required string EncryptedPrivateKey { get; set; }
 
         /// <summary>
+        /// The contents of the registration mail.
+        /// The following placeholders can be used: [[ContactFirstName]] [[GroupName]] [[ParticipantsTable]].
+        /// </summary>
+        public string? RegistrationEmailContent { get; set; }
+
+        /// <summary>
+        /// The contents of the approval mail.
+        /// The following placeholders can be used: [[ContactFirstName]] [[GroupName]] [[ParticipantsTable]].
+        /// </summary>
+        public string? ApprovalEmailContent { get; set; }
+
+        /// <summary>
         /// List of groups.
         /// </summary>
         public required List<GroupOutputModel> Groups { get; set; }

--- a/webapi/FFischbach.Events.API/Program.cs
+++ b/webapi/FFischbach.Events.API/Program.cs
@@ -135,6 +135,7 @@ namespace FFischbach.Events.API
             #region Services
             builder.Services.AddScoped<ICategoryService, CategoryService>();
             builder.Services.AddScoped<IEventService, EventService>();
+            builder.Services.AddScoped<IEmailService, EmailService>();
             builder.Services.AddScoped<IEventManagerService, EventManagerService>();
             builder.Services.AddScoped<IGroupService, GroupService>();
             builder.Services.AddScoped<IParticipantService, ParticipantService>();

--- a/webapi/FFischbach.Events.API/Services/EmailService.cs
+++ b/webapi/FFischbach.Events.API/Services/EmailService.cs
@@ -1,0 +1,177 @@
+﻿using FFischbach.Events.API.Models;
+using FFischbach.Events.API.Models.InputModels;
+using FFischbach.Events.API.Services.Interfaces;
+using MailKit.Net.Smtp;
+using MimeKit;
+
+namespace FFischbach.Events.API.Services
+{
+    public class EmailService(IConfiguration configuration) : IEmailService
+    {
+        private IConfiguration Configuration { get; } = configuration;
+
+        public async Task SendRegistrationMailAsync(GroupCreateModel group, Event @event)
+        {
+            // Create email message with standard sender and receiver information.
+            MimeMessage message = new MimeMessage();
+            message.From.Add(new MailboxAddress("Freiwillige Feuerwehr Fischbach Events", Configuration["Email:FromAddress"])); // Send from a configured mail address.
+            message.To.Add(new MailboxAddress("", group.Contact!.Email));                                                       // Send to the group contact mail.
+            message.ReplyTo.Add(new MailboxAddress("", Configuration["Email:ReplyToAddress"]));                                 // Make receivers reply to a configured mail address.
+            message.Subject = $"Gruppenanmeldung {@event.Id} eingegangen";                                                  // Set subject.
+
+            // Join participants with contact to gain a complete participants list.
+            List<ParticipantGroupCreateModel> allParticipants = [group.Contact, .. group.Participants!];
+
+            // Create table rows for each participant.
+            string tableRows = "";
+            foreach (ParticipantGroupCreateModel participant in allParticipants)
+            {
+                tableRows += $@"
+<tr>
+    <td style='padding: 8px; border-bottom: 1px solid #ddd;'>{participant.FirstName} {participant.LastName}</td>
+    <td style='padding: 8px; border-bottom: 1px solid #ddd;'>{participant.BirthDate:dd.MM.yyyy}</td>
+</tr>";
+            }
+
+            // Create the participants table.
+            string participantTableHtml = $@"
+<table style='width: 100%; border-collapse: collapse; font-size: 15px;'>
+    <thead>
+        <tr style='background: #f0f0f0;'>
+            <th align='left' style='padding: 8px;'>Name</th>
+            <th align='left' style='padding: 8px;'>Geburtsdatum</th>
+        </tr>
+    </thead>
+    <tbody>
+        {tableRows}
+    </tbody>
+</table>
+";
+
+            // Replace the placeholders in the event mail contents.
+            string emailContent = @event.RegistrationEmailContent!
+                .Replace("[[ContactFirstName]]", group.Contact.FirstName)
+                .Replace("[[GroupName]]", group.Name)
+                .Replace("[[ParticipantsTable]]", participantTableHtml);
+
+            // Create the email html body and insert the contents.
+            string html = $@"
+<!DOCTYPE html>
+<html lang='de'>
+<body style='font-family: Arial, sans-serif; background: #fafafa; padding: 20px;'>
+    <div style='max-width: 600px; margin: auto; background: white; border-radius: 6px; padding: 20px; border: 1px solid #e6e6e6;'>
+        {emailContent}
+    </div>
+</body>
+</html>";
+
+            // Assign the html content as mail body.
+            message.Body = new TextPart("html")
+            {
+                Text = html
+            };
+
+            // Send the mail to the contact.
+            await SendMailAsync(message);
+        }
+
+        public async Task SendApprovalMailAsync(GroupApprovalModel group, Event @event)
+        {
+            // Create email message with standard sender and receiver information.
+            MimeMessage message = new MimeMessage();
+            message.From.Add(new MailboxAddress("Freiwillige Feuerwehr Fischbach RAUP", Configuration["Email:FromAddress"]));   // Send from a configured mail address.
+            message.To.Add(new MailboxAddress("", group.Contact!.Email));                                                       // Send to the group contact mail.
+            message.ReplyTo.Add(new MailboxAddress("", Configuration["Email:ReplyToAddress"]));                                 // Make receivers reply to a configured mail address.
+            message.Subject = $"Gruppenanmeldung {@event.Id} genehmigt";                                                  // Set subject.
+
+            // Join participants with contact to gain a complete participants list.
+            List<ParticipantGroupApprovalModel> allParticipants = [group.Contact, .. group.Participants!];
+
+            // Create table rows for each participant.
+            string tableRows = "";
+            foreach (ParticipantGroupApprovalModel participant in allParticipants)
+            {
+                tableRows += $@"
+<tr>
+    <td style='padding: 8px; border-bottom: 1px solid #ddd;'>{participant.FirstName} {participant.LastName}</td>
+    <td style='padding: 8px; border-bottom: 1px solid #ddd;'>{participant.BirthDate:dd.MM.yyyy}</td>
+    <td style='padding: 8px; border-bottom: 1px solid #ddd;'>
+        {(participant.VIP == true ? "<span style='color:#daa520; font-weight:bold;'>VIP</span>" : "—")}
+    </td>
+</tr>";
+            }
+
+            // Create the participants table.
+            string participantTableHtml = $@"
+<table style='width: 100%; border-collapse: collapse; font-size: 15px;'>
+    <thead>
+        <tr style='background: #f0f0f0;'>
+            <th align='left' style='padding: 8px;'>Name</th>
+            <th align='left' style='padding: 8px;'>Geburtsdatum</th>
+            <th align='left' style='padding: 8px;'>VIP</th>
+        </tr>
+    </thead>
+    <tbody>
+        {tableRows}
+    </tbody>
+</table>
+";
+
+            // Replace the placeholders in the event mail contents.
+            string emailContent = @event.ApprovalEmailContent!
+                .Replace("[[ContactFirstName]]", group.Contact.FirstName)
+                .Replace("[[GroupName]]", group.Name)
+                .Replace("[[ParticipantsTable]]", participantTableHtml);
+
+            // Create the email html body and insert the contents.
+            string html = $@"
+<!DOCTYPE html>
+<html lang='de'>
+<body style='font-family: Arial, sans-serif; background: #fafafa; padding: 20px;'>
+    <div style='max-width: 600px; margin: auto; background: white; border-radius: 6px; padding: 20px; border: 1px solid #e6e6e6;'>
+        {emailContent}
+    </div>
+</body>
+</html>";
+
+            // Assign the html content as mail body.
+            message.Body = new TextPart("html")
+            {
+                Text = html
+            };
+
+            // Send the mail to the contact.
+            await SendMailAsync(message);
+        }
+
+        /// <summary>
+        /// Sends a mail to a pre-configured smtp server.
+        /// </summary>
+        /// <param name="message"></param>
+        /// <returns></returns>
+        private async Task SendMailAsync(MimeMessage message)
+        {
+            // Initialize the mail kit smtp client. (opens tcp port etc.)
+            using SmtpClient client = new SmtpClient();
+
+            try
+            {
+                // Connect and authorized at the smtp server.
+                await client.ConnectAsync(Configuration["Email:Host"], Configuration.GetValue<int>("Email:Port"), MailKit.Security.SecureSocketOptions.StartTls);
+                await client.AuthenticateAsync(Configuration["Email:FromAddress"], Configuration["Email:Password"]);
+
+                // Send the prepared mail.
+                await client.SendAsync(message);
+            }
+            catch (Exception)
+            {
+                throw;
+            }
+            finally
+            {
+                // Disonnect the smtp client. (closes tcp port etc.)
+                await client.DisconnectAsync(true);
+            }
+        }
+    }
+}

--- a/webapi/FFischbach.Events.API/Services/EmailService.cs
+++ b/webapi/FFischbach.Events.API/Services/EmailService.cs
@@ -16,8 +16,10 @@ namespace FFischbach.Events.API.Services
             MimeMessage message = new MimeMessage();
             message.From.Add(new MailboxAddress("Freiwillige Feuerwehr Fischbach Events", Configuration["Email:FromAddress"])); // Send from a configured mail address.
             message.To.Add(new MailboxAddress("", group.Contact!.Email));                                                       // Send to the group contact mail.
+            string[]? ccAddresses = Configuration.GetSection("Email:CcAddresses").Get<string[]>();
+            ccAddresses?.ToList().ForEach(cc => message.Cc.Add(new MailboxAddress("", cc)));                                    // Add cc mail addresses.
             message.ReplyTo.Add(new MailboxAddress("", Configuration["Email:ReplyToAddress"]));                                 // Make receivers reply to a configured mail address.
-            message.Subject = $"Gruppenanmeldung {@event.Id} eingegangen";                                                  // Set subject.
+            message.Subject = $"Gruppenanmeldung {@event.Id} eingegangen";                                                      // Set subject.
 
             // Join participants with contact to gain a complete participants list.
             List<ParticipantGroupCreateModel> allParticipants = [group.Contact, .. group.Participants!];
@@ -81,8 +83,10 @@ namespace FFischbach.Events.API.Services
             MimeMessage message = new MimeMessage();
             message.From.Add(new MailboxAddress("Freiwillige Feuerwehr Fischbach RAUP", Configuration["Email:FromAddress"]));   // Send from a configured mail address.
             message.To.Add(new MailboxAddress("", group.Contact!.Email));                                                       // Send to the group contact mail.
+            string[]? ccAddresses = Configuration.GetSection("Email:CcAddresses").Get<string[]>();
+            ccAddresses?.ToList().ForEach(cc => message.Cc.Add(new MailboxAddress("", cc)));                                    // Add cc mail addresses.
             message.ReplyTo.Add(new MailboxAddress("", Configuration["Email:ReplyToAddress"]));                                 // Make receivers reply to a configured mail address.
-            message.Subject = $"Gruppenanmeldung {@event.Id} genehmigt";                                                  // Set subject.
+            message.Subject = $"Gruppenanmeldung {@event.Id} genehmigt";                                                        // Set subject.
 
             // Join participants with contact to gain a complete participants list.
             List<ParticipantGroupApprovalModel> allParticipants = [group.Contact, .. group.Participants!];

--- a/webapi/FFischbach.Events.API/Services/EventService.cs
+++ b/webapi/FFischbach.Events.API/Services/EventService.cs
@@ -11,13 +11,13 @@ using System.Text;
 
 namespace FFischbach.Events.API.Services
 {
-#pragma warning disable CA1862 // Use the 'StringComparison' method overloads to perform case-insensitive string comparisons
-    internal class EventService(ILogger<EventService> logger, IMapper mapper, DatabaseContext databaseContext, IUserService userService) : IEventService
+    internal class EventService(ILogger<EventService> logger, IMapper mapper, DatabaseContext databaseContext, IUserService userService, IEmailService emailService) : IEventService
     {
         private ILogger<EventService> Logger { get; } = logger;
         private IMapper Mapper { get; } = mapper;
         private DatabaseContext DatabaseContext { get; } = databaseContext;
         private IUserService UserService { get; } = userService;
+        private IEmailService EmailService { get; } = emailService;
 
         public async Task<EventDetailOutputModel> CreateEventAsync(ClaimsPrincipal user, EventCreateModel @event)
         {
@@ -416,6 +416,158 @@ namespace FFischbach.Events.API.Services
             }
             return returnValue;
         }
+
+        public async Task SendTestRegistrationMail(ClaimsPrincipal user, string id)
+        {
+            try
+            {
+                // Get user display name.
+                string displayName = UserService.GetDisplayName(user);
+
+                // Get event from the database.
+                Event? dbEvent = await DatabaseContext.Events
+                                        .Include(x => x.Groups!)
+                                            .ThenInclude(x => x.Participants)
+                                        .Include(x => x.EventManagers!)
+                                            .ThenInclude(x => x.Manager)
+                                        .FirstOrDefaultAsync(x => x.Id.ToLower() == id!.ToLower());
+
+                // Check db response.
+                if (dbEvent == null)
+                {
+                    // Nothing found.
+                    throw new CustomException("Das Event konnte nicht gefunden werden.", statusCode: StatusCodes.Status404NotFound);
+                }
+                else if (!dbEvent.EventManagers!.Any(x => x.Manager!.Email.Equals(displayName, StringComparison.CurrentCultureIgnoreCase)))
+                {
+                    // Calling user is not an event manager of that group.
+                    throw new CustomException("Du hast keine Berechtigungen für dieses Event. Lass dich von einem Manager des Events hinzufügen.", statusCode: StatusCodes.Status403Forbidden);
+                }
+                else if (dbEvent.Completed)
+                {
+                    // Event is already completed.
+                    throw new CustomException("Das Event ist bereits abgeschlossen, es können keine Änderungen mehr daran vorgenommen werden.", statusCode: StatusCodes.Status400BadRequest);
+                }
+
+                // Create a dummy group.
+                GroupCreateModel dummyGroup = new GroupCreateModel
+                {
+                    Name = "Testgruppe",
+                    EventId = dbEvent.Id,
+                    Contact = new ParticipantGroupCreateModel
+                    {
+                        FirstName = "Max",
+                        LastName = "Mustermann",
+                        BirthDate = DateOnly.FromDateTime(DateTime.Now.AddYears(-22)),
+                        Email = displayName
+                    },
+                    Participants = new List<ParticipantGroupCreateModel>
+                    {
+                        new ParticipantGroupCreateModel
+                        {
+                            FirstName = "Robert",
+                            LastName = "Mustermann",
+                            BirthDate = DateOnly.FromDateTime(DateTime.Now.AddYears(-25))
+                        },
+                        new ParticipantGroupCreateModel
+                        {
+                            FirstName = "Erika",
+                            LastName = "Musterfrau",
+                            BirthDate = DateOnly.FromDateTime(DateTime.Now.AddYears(-30))
+                        }
+                    }
+                };
+
+                // Send the registration mail.
+                await EmailService.SendRegistrationMailAsync(dummyGroup, dbEvent);
+            }
+            catch (CustomException ex)
+            {
+                Logger.LogWarning(ex, "Failed to send test registration mail for event '{id}'.", id);
+                throw;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Failed to send test registration mail for event '{id}'.", id);
+                throw new CustomException("Unerwarteter Fehler beim Senden der Test-Mail.", ex);
+            }
+        }
+
+        public async Task SendTestApprovalMail(ClaimsPrincipal user, string id)
+        {
+            try
+            {
+                // Get user display name.
+                string displayName = UserService.GetDisplayName(user);
+
+                // Get event from the database.
+                Event? dbEvent = await DatabaseContext.Events
+                                        .Include(x => x.Groups!)
+                                            .ThenInclude(x => x.Participants)
+                                        .Include(x => x.EventManagers!)
+                                            .ThenInclude(x => x.Manager)
+                                        .FirstOrDefaultAsync(x => x.Id.ToLower() == id!.ToLower());
+
+                // Check db response.
+                if (dbEvent == null)
+                {
+                    // Nothing found.
+                    throw new CustomException("Das Event konnte nicht gefunden werden.", statusCode: StatusCodes.Status404NotFound);
+                }
+                else if (!dbEvent.EventManagers!.Any(x => x.Manager!.Email.Equals(displayName, StringComparison.CurrentCultureIgnoreCase)))
+                {
+                    // Calling user is not an event manager of that group.
+                    throw new CustomException("Du hast keine Berechtigungen für dieses Event. Lass dich von einem Manager des Events hinzufügen.", statusCode: StatusCodes.Status403Forbidden);
+                }
+                else if (dbEvent.Completed)
+                {
+                    // Event is already completed.
+                    throw new CustomException("Das Event ist bereits abgeschlossen, es können keine Änderungen mehr daran vorgenommen werden.", statusCode: StatusCodes.Status400BadRequest);
+                }
+
+                // Create a dummy group.
+                GroupApprovalModel dummyGroup = new GroupApprovalModel
+                {
+                    Name = "Testgruppe",
+                    Contact = new ParticipantGroupApprovalModel
+                    {
+                        FirstName = "Max",
+                        LastName = "Mustermann",
+                        BirthDate = DateOnly.FromDateTime(DateTime.Now.AddYears(-22)),
+                        VIP = true,
+                        Email = displayName
+                    },
+                    Participants = new List<ParticipantGroupApprovalModel>
+                    {
+                        new ParticipantGroupApprovalModel
+                        {
+                            FirstName = "Robert",
+                            LastName = "Mustermann",
+                            BirthDate = DateOnly.FromDateTime(DateTime.Now.AddYears(-25))
+                        },
+                        new ParticipantGroupApprovalModel
+                        {
+                            FirstName = "Erika",
+                            LastName = "Musterfrau",
+                            BirthDate = DateOnly.FromDateTime(DateTime.Now.AddYears(-30)),
+                            VIP = true
+                        }
+                    }
+                };
+
+                // Send the registration mail.
+                await EmailService.SendApprovalMailAsync(dummyGroup, dbEvent);
+            }
+            catch (CustomException ex)
+            {
+                Logger.LogWarning(ex, "Failed to send test approval mail for event '{id}'.", id);
+                throw;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Failed to send test approval mail for event '{id}'.", id);
+                throw new CustomException("Unerwarteter Fehler beim Senden der Test-Mail.", ex);
+            }
+        }
     }
-#pragma warning restore CA1862 // Use the 'StringComparison' method overloads to perform case-insensitive string comparisons
 }

--- a/webapi/FFischbach.Events.API/Services/GroupService.cs
+++ b/webapi/FFischbach.Events.API/Services/GroupService.cs
@@ -10,13 +10,13 @@ using System.Security.Claims;
 
 namespace FFischbach.Events.API.Services
 {
-#pragma warning disable CA1862 // Use the 'StringComparison' method overloads to perform case-insensitive string comparisons
-    public class GroupService(ILogger<GroupService> logger, IMapper mapper, DatabaseContext databaseContext, IUserService userService) : IGroupService
+    public class GroupService(ILogger<GroupService> logger, IMapper mapper, DatabaseContext databaseContext, IUserService userService, IEmailService emailService) : IGroupService
     {
         private ILogger<GroupService> Logger { get; } = logger;
         private IMapper Mapper { get; } = mapper;
         private DatabaseContext DatabaseContext { get; } = databaseContext;
         private IUserService UserService { get; } = userService;
+        private IEmailService EmailService { get; } = emailService;
 
         public async Task CreateGroupAsync(GroupCreateModel group)
         {
@@ -70,6 +70,9 @@ namespace FFischbach.Events.API.Services
                 // Create the group.
                 DatabaseContext.Groups.Add(dbGroup);
                 await DatabaseContext.SaveChangesAsync();
+
+                // Send a confirmation mail.
+                await EmailService.SendRegistrationMailAsync(group, dbEvent);
             }
             catch (CustomException ex)
             {
@@ -287,6 +290,58 @@ namespace FFischbach.Events.API.Services
                 throw new CustomException("Unerwarteter Fehler beim Löschen der Gruppe.", ex);
             }
         }
+
+        public async Task SendApprovalMailAsync(ClaimsPrincipal user, int id, GroupApprovalModel group)
+        {
+            try
+            {
+                // Get user display name.
+                string displayName = UserService.GetDisplayName(user);
+
+                // Get group from the database.
+                Group? dbGroup = await DatabaseContext.Groups
+                                        .Include(x => x.Participants!)
+                                        .Include(x => x.Category)
+                                        .Include(x => x.Event!)
+                                            .ThenInclude(x => x.EventManagers!)
+                                                .ThenInclude(x => x.Manager)
+                                        .FirstOrDefaultAsync(x => x.Id == id);
+
+                // Check db response.
+                if (dbGroup == null)
+                {
+                    // Nothing found.
+                    throw new CustomException("Die Gruppe konnte nicht gefunden werden.", statusCode: StatusCodes.Status400BadRequest);
+                }
+                if (!dbGroup.Event!.EventManagers!.Any(x => x.Manager!.Email.Equals(displayName, StringComparison.CurrentCultureIgnoreCase)))
+                {
+                    // Calling user is not an event manager of that group.
+                    throw new CustomException("Du hast keine Berechtigungen für Gruppen dieses Events. Lass dich von einem Manager des Events hinzufügen.", statusCode: StatusCodes.Status403Forbidden);
+                }
+                if (dbGroup.Event!.Completed)
+                {
+                    // Event is already completed.
+                    throw new CustomException("Das Event ist bereits abgeschlossen, es können keine Änderungen mehr daran vorgenommen werden.", statusCode: StatusCodes.Status400BadRequest);
+                }
+                if (dbGroup.Approved != true)
+                {
+                    // Group is not yet approved.
+                    throw new CustomException("Du kannst Genehmigungs-Mails nur an Gruppen schicken, die bereits genehmigt sind.", statusCode: StatusCodes.Status403Forbidden);
+                }
+
+                // Use the email service to send the approval mail.
+                await EmailService.SendApprovalMailAsync(group, dbGroup.Event);
+            }
+            catch (CustomException ex)
+            {
+                Logger.LogWarning(ex, "Failed to send approval mail to group '{id}'.", id);
+                throw;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Failed to send approval mail to group '{id}'.", id);
+                throw new CustomException("Unerwarteter Fehler beim Senden der Genehmigungs-Email an die Gruppe.", ex);
+            }
+        }
     }
-#pragma warning restore CA1862 // Use the 'StringComparison' method overloads to perform case-insensitive string comparisons
 }

--- a/webapi/FFischbach.Events.API/Services/Interfaces/IEmailService.cs
+++ b/webapi/FFischbach.Events.API/Services/Interfaces/IEmailService.cs
@@ -1,0 +1,24 @@
+﻿using FFischbach.Events.API.Models;
+using FFischbach.Events.API.Models.InputModels;
+
+namespace FFischbach.Events.API.Services.Interfaces
+{
+    public interface IEmailService
+    {
+        /// <summary>
+        /// Sends the registration email to the group's contact person.
+        /// </summary>
+        /// <param name="group"></param>
+        /// <param name="event"></param>
+        /// <returns></returns>
+        Task SendRegistrationMailAsync(GroupCreateModel group, Event @event);
+
+        /// <summary>
+        /// Sends the approval email to the group's contact person.
+        /// </summary>
+        /// <param name="group"></param>
+        /// <param name="event"></param>
+        /// <returns></returns>
+        Task SendApprovalMailAsync(GroupApprovalModel group, Event @event);
+    }
+}

--- a/webapi/FFischbach.Events.API/Services/Interfaces/IEventService.cs
+++ b/webapi/FFischbach.Events.API/Services/Interfaces/IEventService.cs
@@ -54,5 +54,21 @@ namespace FFischbach.Events.API.Services.Interfaces
         /// <returns>The html document as string.</returns>
         /// <exception cref="CustomException"></exception>
         Task<string> GetSignUpFormAsync(string id);
+
+        /// <summary>
+        /// Sends a test registration mail for the event to the current user.
+        /// </summary>
+        /// <param name="user"></param>
+        /// <param name="id"></param>
+        /// <returns></returns>
+        Task SendTestRegistrationMail(ClaimsPrincipal user, string id);
+
+        /// <summary>
+        /// Sends a test approval mail for the event to the current user.
+        /// </summary>
+        /// <param name="user"></param>
+        /// <param name="id"></param>
+        /// <returns></returns>
+        Task SendTestApprovalMail(ClaimsPrincipal user, string id);
     }
 }

--- a/webapi/FFischbach.Events.API/Services/Interfaces/IGroupService.cs
+++ b/webapi/FFischbach.Events.API/Services/Interfaces/IGroupService.cs
@@ -38,5 +38,14 @@ namespace FFischbach.Events.API.Services.Interfaces
         /// <param name="id"></param>
         /// <exception cref="CustomException"></exception>
         Task DeleteGroupAsync(ClaimsPrincipal user, int id);
+
+        /// <summary>
+        /// Sends the approval email to the group's contact person.
+        /// </summary>
+        /// <param name="user"></param>
+        /// <param name="id"></param>
+        /// <param name="group"></param>
+        /// <returns></returns>
+        Task SendApprovalMailAsync(ClaimsPrincipal user, int id, GroupApprovalModel group);
     }
 }

--- a/webui/src/app/[event_id]/Categories.tsx
+++ b/webui/src/app/[event_id]/Categories.tsx
@@ -56,14 +56,16 @@ export const Categories: FC<CategoriesProps> = (props: CategoriesProps) => {
         <TD>
           <ConfirmPopup
             title={`Kategorie "${category.name}" löschen?`}
-            done={async () => {
-              deleteCategory(category.id)
-                .then(() => {
-                  const updatedList = props.state.categories.filter((c) => c.id != category.id);
-                  props.dispatch({ categories: updatedList });
-                  addToast({ message: "Kategorie gelöscht", type: "info" });
-                })
-                .catch((e) => errorHandler(e));
+            done={async (isConfirmed) => {
+              if (isConfirmed) {
+                deleteCategory(category.id)
+                  .then(() => {
+                    const updatedList = props.state.categories.filter((c) => c.id != category.id);
+                    props.dispatch({ categories: updatedList });
+                    addToast({ message: "Kategorie gelöscht", type: "info" });
+                  })
+                  .catch((e) => errorHandler(e));
+              }
             }}
           >
             <TrashIcon color="red" height={25} />

--- a/webui/src/app/[event_id]/[group_id]/page.tsx
+++ b/webui/src/app/[event_id]/[group_id]/page.tsx
@@ -26,6 +26,7 @@ import { useGroupService } from "@/services/groupsService";
 import useErrorHandler from "@/services/errorHandler";
 import { useParticipantService } from "@/services/participantService";
 import { useParams } from "next/navigation";
+import { useEmail as useEmail } from "@/services/emailService";
 
 const GroupPage = () => {
   const params = useParams<{ event_id: string; group_id: string }>();
@@ -37,10 +38,11 @@ const GroupPage = () => {
   const { getGroup, updateGroup } = useGroupService();
   const [, setIsPending] = useState<boolean>();
   const { addToast } = useToast();
+  const { sendApprovalEmail } = useEmail();
   const { getEventById } = useEventService();
   const errorHandler = useErrorHandler();
   const [categories, setCategories] = useCategories();
-  const { addContact } = useParticipantService();
+  const { putEvent } = useEventService();
 
   /*const [participantToSwap, setParticipantToSwap] = useState<ParticipantEdit | undefined>(
     undefined
@@ -89,7 +91,6 @@ const GroupPage = () => {
   }, [groupState, eventSettings]);
 
   const onSubmit: any = () => {
-    console.log(participants);
     groupState.participants = participants;
 
     updateGroup(groupState)
@@ -97,6 +98,16 @@ const GroupPage = () => {
         addToast({ message: "Gruppe aktualisiert", type: "info" });
 
         dispatchGroup({ type: "new", value: groupState });
+      })
+      .then(() => {
+        if (groupState.approved) {
+          sendApprovalEmail(groupState).then(() =>
+            addToast({
+              message: "Genehmigungsbestätigung gesendet",
+              type: "info",
+            })
+          );
+        }
       })
       .catch((e) => errorHandler(e));
   };
@@ -314,7 +325,7 @@ const GroupPage = () => {
         disabled={isEncrypted}
         value={!!groupState.approved}
         onChange={(e: ChangeEvent<HTMLInputElement>) => {
-          groupState.approved = e.target.checked;
+          dispatchGroup({ type: "approved", value: e.target.checked });
         }}
       />
 
@@ -364,7 +375,7 @@ const GroupPage = () => {
             disabled={isEncrypted}
             value={!!groupState.contact.vip}
             onChange={(e: ChangeEvent<HTMLInputElement>) => {
-              groupState.contact.vip = e.target.checked;
+              dispatchGroup({ type: "contact_vip", value: e.target.checked });
             }}
           />
         </div>
@@ -392,7 +403,7 @@ const GroupPage = () => {
         }
       />
       {!isEncrypted && (
-        <div className="flex flex-row justify-end">
+        <div className="flex flex-row justify-end gap-3">
           <Button color="blue" type="button" onClick={onSubmit}>
             Gruppe updaten
           </Button>

--- a/webui/src/app/[event_id]/page.tsx
+++ b/webui/src/app/[event_id]/page.tsx
@@ -1,13 +1,6 @@
 "use client";
 
-import {
-  ReactNode,
-  Reducer,
-  useLayoutEffect,
-  useMemo,
-  useReducer,
-  useState,
-} from "react";
+import { ReactNode, Reducer, useLayoutEffect, useMemo, useReducer, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { Group } from "@/models/in/Group";
 import { Event } from "@/models/in/Event";
@@ -34,6 +27,8 @@ import { EditEvent } from "@/models/EditEvent";
 import { DataList } from "@/components/DataList";
 import { useEventService } from "@/services/eventsService";
 import useErrorHandler from "@/services/errorHandler";
+import { EmailEditorPopup } from "@/components/popups/EmailEditorPopup";
+import { useEmail } from "@/services/emailService";
 
 const EventPage = () => {
   const router = useRouter();
@@ -46,14 +41,19 @@ const EventPage = () => {
   const { parse } = useJsonToCsv();
   const errorHandler = useErrorHandler();
 
-  const { getEventById, setEventCompleted, addEventManager, putEvent } =
-    useEventService();
+  const { getEventById, setEventCompleted, addEventManager, putEvent } = useEventService();
+  const {
+    sendTestApprovalEmail,
+    sendApprovalEmail,
+    sendRegistrationEmail,
+    sendTestRegistrationEmail,
+  } = useEmail();
 
   const [filter, dispatchFilter] = useFilterSettings();
 
   const tableHeaders = useMemo(
     () => ["Name", "Kategorie", "Kontakt", "Genehmigt", "Erstellt", ""],
-    [],
+    []
   );
 
   const [state, dispatch] = useReducer<Event, [Action<Partial<Event>>]>(
@@ -63,7 +63,7 @@ const EventPage = () => {
         ...action,
       };
     },
-    new Event("", "", "", 1, 1, false, "", [], "", "", "", []),
+    new Event("", "", "", 1, 1, false, "", [], "", "", "", "", "", [])
   );
 
   useLayoutEffect(() => {
@@ -74,11 +74,7 @@ const EventPage = () => {
       .then((event: Event) => {
         dispatch(event);
         setIsPending(false);
-        if (
-          eventSettings &&
-          eventSettings.password &&
-          eventSettings.eventId == params.event_id
-        ) {
+        if (eventSettings && eventSettings.password && eventSettings.eventId == params.event_id) {
           onDecryptEvent(eventSettings.password, false, event);
         }
       })
@@ -87,17 +83,15 @@ const EventPage = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const onCompleteEvent = () => {
-    setEventCompleted(params.event_id)
-      .then(() => addToast({ message: "Event beendet", type: "info" }))
-      .catch((e) => errorHandler(e));
+  const onCompleteEvent = (isConfirmed: boolean) => {
+    if (isConfirmed) {
+      setEventCompleted(params.event_id)
+        .then(() => addToast({ message: "Event beendet", type: "info" }))
+        .catch((e) => errorHandler(e));
+    }
   };
 
-  const onDecryptEvent = async (
-    password: string,
-    isManual?: boolean,
-    localState?: Event,
-  ) => {
+  const onDecryptEvent = async (password: string, isManual?: boolean, localState?: Event) => {
     try {
       if (!localState) {
         localState = state;
@@ -111,6 +105,8 @@ const EventPage = () => {
       if (isManual) {
         addToast({ message: "Entschlüsselt", type: "info" });
       }
+
+      console.log(state);
     } catch (e) {
       throw new Error("Falsches Passwort");
     }
@@ -156,10 +152,7 @@ const EventPage = () => {
     );
   };
 
-  const generateFilteredList = (
-    filter: string,
-    isApproved?: boolean,
-  ): ReactNode[] => {
+  const generateFilteredList = (filter: string, isApproved?: boolean): ReactNode[] => {
     const filteredList = state.groups
       ?.filter((group: Group) => {
         const f = filter ?? "";
@@ -194,11 +187,7 @@ const EventPage = () => {
   return (
     <>
       {state.completed && <InfoBadge text="Event ist beendet" />}
-      <PasswordPopup
-        title="Event entschlüsseln"
-        disabled={!isEncrypted}
-        done={onDecryptEvent}
-      >
+      <PasswordPopup title="Event entschlüsseln" disabled={!isEncrypted} done={onDecryptEvent}>
         <Lock isLocked={isEncrypted} />
       </PasswordPopup>
 
@@ -213,60 +202,86 @@ const EventPage = () => {
       </div>
       <div className="flex flex-row gap-3">
         <div>Veranstaltungsdatum:</div>
-        <div className="text-base font-semibold">
-          {getLocalDateTime(state?.date)}
-        </div>
+        <div className="text-base font-semibold">{getLocalDateTime(state?.date)}</div>
       </div>
       {!state.completed && !isEncrypted && (
-        <div className="flex flex-row gap-3 flex-wrap">
-          <EditEventPopup
-            event={state}
-            done={async (editedEvent: EditEvent) => {
-              putEvent(state.id, editedEvent)
-                .then(() => {
-                  dispatch(editedEvent);
-                  addToast({
-                    message: "Event aktualisiert",
-                    type: "info",
-                  });
-                })
-                .catch((e) => errorHandler(e));
-            }}
-          >
-            <Button
-              color="blue"
-              className="md:flex-none flex-1 text-white"
-              type="button"
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-row gap-3 flex-wrap">
+            <EditEventPopup
+              event={state}
+              done={async (editedEvent: EditEvent) => {
+                putEvent(state.id, editedEvent)
+                  .then(() => {
+                    dispatch(editedEvent);
+                    addToast({
+                      message: "Event aktualisiert",
+                      type: "info",
+                    });
+                  })
+                  .catch((e) => errorHandler(e));
+              }}
             >
-              Event bearbeiten
-            </Button>
-          </EditEventPopup>
+              <Button color="blue" className="md:flex-none flex-1 text-white" type="button">
+                Event bearbeiten
+              </Button>
+            </EditEventPopup>
 
-          <AddEventManagerPopup done={onAddEventManager}>
+            <AddEventManagerPopup done={onAddEventManager}>
+              <Button color="blue" className="md:flex-none flex-1 text-white" type="button">
+                Manager hinzufügen
+              </Button>
+            </AddEventManagerPopup>
             <Button
               color="blue"
               className="md:flex-none flex-1 text-white"
               type="button"
+              onClick={async () => { 
+                await download();
+                addToast({ message: "Event exportiert", type: "info" });
+              }}
             >
-              Manager hinzufügen
+              Event exportieren
             </Button>
-          </AddEventManagerPopup>
-          <Button
-            color="blue"
-            className="md:flex-none flex-1 text-white"
-            type="button"
-            onClick={async () => {
-              await download();
-              addToast({ message: "Event exportiert", type: "info" });
-            }}
-          >
-            Event exportieren
-          </Button>
-          <ConfirmPopup title="Event beenden" done={onCompleteEvent}>
-            <Button className="md:flex-none flex-1" type="button">
-              Event beenden
-            </Button>
-          </ConfirmPopup>
+            <ConfirmPopup title="Event beenden" done={onCompleteEvent}>
+              <Button className="md:flex-none flex-1" type="button">
+                Event beenden
+              </Button>
+            </ConfirmPopup>
+          </div>
+          <div className="flex flex-row gap-3">
+            <EmailEditorPopup
+              title="Email Bestätigung bearbeiten (HTML)"
+              sendTestAction={sendTestApprovalEmail}
+              eventId={params.event_id}
+              emailContent={state.approvalEmailContent}
+              done={async (approvalEmailContent) => {
+                dispatch({ approvalEmailContent });
+                const tempEvent: Event = { ...state, approvalEmailContent };
+
+                await putEvent(params.event_id, tempEvent);
+              }}
+            >
+              <Button color="blue" className="md:flex-none flex-1 text-white" type="button">
+                Genehmigungsmail bearbeiten
+              </Button>
+            </EmailEditorPopup>
+            <EmailEditorPopup
+              title="Eingangsbestätigung bearbeiten (HTML)"
+              sendTestAction={sendTestRegistrationEmail}
+              eventId={params.event_id}
+              emailContent={state.registrationEmailContent}
+              done={async (registrationEmailContent) => {
+                dispatch({ registrationEmailContent });
+                const tempEvent: Event = { ...state, registrationEmailContent };
+
+                await putEvent(params.event_id, tempEvent);
+              }}
+            >
+              <Button color="blue" className="md:flex-none flex-1 text-white" type="button">
+                Registrierungsmail bearbeiten
+              </Button>
+            </EmailEditorPopup>
+          </div>
         </div>
       )}
       <div className="flex flex-col gap-3">
@@ -282,14 +297,11 @@ const EventPage = () => {
             dispatchFilter({
               eventDetail: {
                 groupFilter: value,
-                groupFilterApproved:
-                  filter.eventDetail?.groupFilterApproved ?? "",
+                groupFilterApproved: filter.eventDetail?.groupFilterApproved ?? "",
               },
             });
           }}
-          generateList={() =>
-            generateFilteredList(filter.eventDetail?.groupFilter ?? "", false)
-          }
+          generateList={() => generateFilteredList(filter.eventDetail?.groupFilter ?? "", false)}
           tableHeaders={tableHeaders}
         />
 
@@ -308,10 +320,7 @@ const EventPage = () => {
             });
           }}
           generateList={() =>
-            generateFilteredList(
-              filter.eventDetail?.groupFilterApproved ?? "",
-              true,
-            )
+            generateFilteredList(filter.eventDetail?.groupFilterApproved ?? "", true)
           }
           tableHeaders={tableHeaders}
         />

--- a/webui/src/components/Popup.tsx
+++ b/webui/src/components/Popup.tsx
@@ -8,6 +8,7 @@ export interface PopupTitleProps extends HTMLAttributes<HTMLDivElement> {}
 export interface PopupOpenerProps extends HTMLAttributes<HTMLDivElement> {}
 export interface PopupProps extends HTMLAttributes<HTMLDivElement> {
   onClose?(): void;
+  preventClose?: boolean;
   state: {
     open: boolean;
     setOpen: Dispatch<SetStateAction<boolean>>;
@@ -22,7 +23,7 @@ export const PopupDialogPanel: FC<PopupPanelProps> = (props: PopupPanelProps) =>
   return (
     <DialogPanel
       transition
-      className="z-50 w-fit max-w-md rounded-xl border-2 border-gray-500 dark:border-0 bg-gray-400 dark:bg-gray-800 p-6 duration-300 ease-out data-[closed]:transform-[scale(95%)] data-[closed]:opacity-0 shadow-lg"
+      className={`z-50 w-fit max-w-md rounded-xl border-2 border-gray-500 dark:border-0 bg-gray-400 dark:bg-gray-800 p-6 duration-300 ease-out data-[closed]:transform-[scale(95%)] data-[closed]:opacity-0 shadow-lg ${props.className}`}
     >
       {props.children}
     </DialogPanel>
@@ -50,7 +51,9 @@ export const Popup: FC<PopupProps> = (props: PopupProps) => {
           if (!!props.onClose) {
             props.onClose();
           }
-          props.state.setOpen(false);
+          if (!props.preventClose) {
+            props.state.setOpen(false);
+          }
         }}
         className="relative z-10 focus:outline-none"
       >

--- a/webui/src/components/TextArea.tsx
+++ b/webui/src/components/TextArea.tsx
@@ -1,0 +1,17 @@
+import { FC, HTMLAttributes } from "react";
+
+export interface TextAreaProps extends HTMLAttributes<HTMLTextAreaElement> {
+    value: string
+}
+
+export const TextArea: FC<TextAreaProps> = (props: TextAreaProps) => {
+  return (
+    <textarea
+      spellCheck={false}
+      onChange={props.onChange}
+      className={`border-2 border-neutral-400 outline-none focus:border-blue-500 rounded p-2 ${props.className}`}
+     value={props.value}>
+      
+    </textarea>
+  );
+};

--- a/webui/src/components/popups/ConfirmPopup.tsx
+++ b/webui/src/components/popups/ConfirmPopup.tsx
@@ -1,22 +1,15 @@
 import { FC, HTMLAttributes, useEffect, useEffectEvent, useState } from "react";
 import { Button } from "../Button";
-import {
-  PopupBackdrop,
-  PopupDialogPanel,
-  PopupTitle,
-  Popup,
-  PopupOpener,
-} from "../Popup";
+import { PopupBackdrop, PopupDialogPanel, PopupTitle, Popup, PopupOpener } from "../Popup";
 import useErrorHandler from "@/services/errorHandler";
 
 export interface ConfirmPopupProps extends HTMLAttributes<HTMLElement> {
   title?: string;
-  done(): void;
+  done?(isConfirmed: boolean): void;
+  open?: boolean;
 }
 
-export const ConfirmPopup: FC<ConfirmPopupProps> = (
-  props: ConfirmPopupProps,
-) => {
+export const ConfirmPopup: FC<ConfirmPopupProps> = (props: ConfirmPopupProps) => {
   const [errors, setErrors] = useState<string[]>([]);
   const [visible, setVisible] = useState<boolean>(false);
 
@@ -32,9 +25,17 @@ export const ConfirmPopup: FC<ConfirmPopupProps> = (
     }
   }, [visible]);
 
+  useEffect(() => {
+    if (props.open != undefined) {
+      setVisible(props.open);
+    }
+  }, [props.open]);
+
   const onSubmit = async () => {
     try {
-      await props.done();
+      if (props.done) {
+        await props.done(true);
+      }
       setVisible(false);
     } catch (e: any) {
       errorHandler(e, setErrors);
@@ -43,11 +44,7 @@ export const ConfirmPopup: FC<ConfirmPopupProps> = (
 
   const generateErrorMessage = (error: string, index: number) => {
     return (
-      <label
-        key={`create-error-${index}`}
-        htmlFor="form"
-        className="text-red-500"
-      >
+      <label key={`create-error-${index}`} htmlFor="form" className="text-red-500">
         {error}
       </label>
     );
@@ -80,7 +77,12 @@ export const ConfirmPopup: FC<ConfirmPopupProps> = (
                 styletype="secondary"
                 autoFocus={true}
                 type="button"
-                onClick={() => setVisible(false)}
+                onClick={() => {
+                  setVisible(false);
+                  if (props.done) {
+                    props.done(false);
+                  }
+                }}
               >
                 Abbrechen
               </Button>

--- a/webui/src/components/popups/EmailEditorPopup.tsx
+++ b/webui/src/components/popups/EmailEditorPopup.tsx
@@ -1,0 +1,147 @@
+import { ChangeEvent, FC, PropsWithChildren, useEffect, useRef, useState } from "react";
+import { Button } from "../Button";
+import { Popup, PopupBackdrop, PopupDialogPanel, PopupOpener, PopupTitle } from "../Popup";
+import { Event } from "@/models/in/Event";
+import { TextArea } from "../TextArea";
+import { useToast } from "@/context/toast";
+import { ConfirmPopup } from "./ConfirmPopup";
+
+export interface EmailEditorPopupProps extends PropsWithChildren {
+  title: string;
+  done(emailContent: string): Promise<void>;
+  sendTestAction(id: string): Promise<void>;
+  emailContent: string;
+  eventId: string;
+}
+
+export const EmailEditorPopup: FC<EmailEditorPopupProps> = (props: EmailEditorPopupProps) => {
+  const [visible, setVisible] = useState<boolean>(false);
+  const [errors, setErrors] = useState<string[]>([]);
+  const [hasChanges, setHasChanges] = useState<boolean>(false);
+  const [text, setText] = useState<string>(props.emailContent);
+  const [isConfirmDiscard, setIsConfirmDiscard] = useState<boolean>(false);
+
+  const { addToast } = useToast();
+
+  const onSubmit = () => {
+    props.done(text);
+    addToast({
+      message: "Email template gespeichert",
+      type: "info",
+    });
+    setHasChanges(false);
+    setVisible(false);
+  };
+
+  const generateErrorMessage = (error: string, index: number) => {
+    return (
+      <label key={`create-error-${index}`} htmlFor="form" className="text-red-500">
+        {error}
+      </label>
+    );
+  };
+
+  const onSendTest = async () => {
+    await props.done(text);
+
+    setTimeout(() => {
+      props.sendTestAction(props.eventId);
+      setHasChanges(false);
+      addToast({
+        message: "Test email gesendet",
+        type: "info",
+      });
+    }, 1000);
+  };
+
+  useEffect(() => {
+    if (visible) {
+      setText(props.emailContent);
+      setIsConfirmDiscard(false);
+    }
+  }, [visible]);
+
+  return (
+    <>
+      <Popup
+        state={{ open: visible, setOpen: setVisible }}
+        onClose={() => {
+          if (hasChanges) {
+            setIsConfirmDiscard(true);
+          } else {
+            setVisible(false);
+            setHasChanges(false);
+          }
+        }}
+        preventClose
+      >
+        <PopupBackdrop />
+        <PopupDialogPanel className="max-w-screen">
+          <PopupTitle>{props.title}</PopupTitle>
+          <div
+            className="w-fit"
+            onSubmit={(e) => {
+              e.preventDefault();
+              onSubmit();
+            }}
+          >
+            <div id="form" className="mt-2 flex flex-col gap-3 w-[80vw]">
+              <TextArea
+                onChange={(event: ChangeEvent<HTMLTextAreaElement>) => {
+                  if (!hasChanges) {
+                    setHasChanges(true);
+                  }
+
+                  setText(event.target.value);
+                }}
+                className="min-h-[70vh]"
+                value={text}
+              />
+            </div>
+            <div className="flex flex-col gap-2">
+              {errors.map((error: string, index: number) => {
+                return generateErrorMessage(error, index);
+              })}
+            </div>
+            <div className="flex flex-row py-3 gap-3 justify-end">
+              <Button color="blue" type="button" onClick={onSendTest}>
+                Test senden (speichern)
+              </Button>
+
+              <Button color="green" type="button" onClick={() => onSubmit()}>
+                Speichern
+              </Button>
+
+              <Button
+                color="red"
+                styletype="secondary"
+                type="button"
+                onClick={() => {
+                  if (!hasChanges) {
+                    setVisible(false);
+                  }
+                  setIsConfirmDiscard(true);
+                }}
+              >
+                {hasChanges ? "Verwerfen" : "Schließen"}
+              </Button>
+            </div>
+          </div>
+        </PopupDialogPanel>
+        <ConfirmPopup
+          open={isConfirmDiscard && hasChanges}
+          title="Änderungen verwerfen"
+          done={(isConfirmed) => {
+            if (isConfirmed) {
+              setVisible(false);
+              setHasChanges(false);
+            } else {
+              setIsConfirmDiscard(false);
+            }
+          }}
+        />
+      </Popup>
+      <PopupOpener onClick={() => setVisible(true)}>{props.children}</PopupOpener>
+    </>
+  );
+};

--- a/webui/src/models/in/Event.ts
+++ b/webui/src/models/in/Event.ts
@@ -12,10 +12,10 @@ export class Event {
     public encryptedPrivateKey: string,
     public categories: Category[],
     public date: string,
+    public approvalEmailContent: string,
+    public registrationEmailContent: string,
     public privateKey?: string,
     public publicKey?: string,
-    public groups?: Group[],
-    
-  ) {
-  }
+    public groups?: Group[]
+  ) {}
 }

--- a/webui/src/services/emailService.ts
+++ b/webui/src/services/emailService.ts
@@ -1,0 +1,29 @@
+import useClientFetch from "./fetch";
+import { Group } from "@/models/in/Group";
+
+export const useEmail = () => {
+  const { post } = useClientFetch();
+
+  const sendApprovalEmail = async (group: Group) => {
+    return await post(`/Groups/${group.id}/SendApproval`, group);
+  };
+
+  const sendRegistrationEmail = async (groupId: string) => {
+    return await post(`/Groups/${groupId}/SendRegistration`);
+  };
+
+  const sendTestApprovalEmail = async (eventId: string) => {
+    return await post(`/Events/${eventId}/SendTestApprovalMail`);
+  };
+
+  const sendTestRegistrationEmail = async (eventId: string) => {
+    return await post(`/Events/${eventId}/SendTestRegistrationMail`);
+  };
+
+  return {
+    sendApprovalEmail,
+    sendRegistrationEmail,
+    sendTestApprovalEmail,
+    sendTestRegistrationEmail,
+  };
+};

--- a/webui/src/services/eventsService.ts
+++ b/webui/src/services/eventsService.ts
@@ -19,7 +19,7 @@ export const useEventService = () => {
   };
 
   const putEvent = async (id: string, event: EditEvent) => {
-    put(`/Events/${id}`, event);
+    return put(`/Events/${id}`, event);
   };
 
   const setEventCompleted = async (eventId: string) => {

--- a/webui/src/services/fetch.ts
+++ b/webui/src/services/fetch.ts
@@ -52,13 +52,15 @@ const useClientFetch = () => {
       body: data ? JSON.stringify(data) : undefined,
     });
 
-    const result = await response.json();
+    if (response.status != 204) {
+      const result = await response.json();
 
-    if (!response.ok) {
-      throw new ResponseException(result as ResponseError);
+      if (!response.ok) {
+        throw new ResponseException(result as ResponseError);
+      }
+
+      return result;
     }
-
-    return result;
   };
 
   const put = async (path: string, data: T): Promise<T> => {


### PR DESCRIPTION
- One new endpoint for sending approval emails manually
- Registration emails will be sent automatically
- New properties on model event for configuring the email contents
- Two new endpoints on /events for testing the registration and approval mail contents with a dummy group
- Database migration for the two new event properties
- Nuget upgrades
- New EmailService including interface