### PR TITLE
fix(text-encoding): correct text-encoding export

### DIFF
--- a/webui/src/services/privateKeyService.ts
+++ b/webui/src/services/privateKeyService.ts
@@ -1,9 +1,9 @@
-import { ab2str, base64ToArrayBuffer, str2ab } from "@/util/converter";
+import { ab2str, str2ab } from "@/util/converter";
 import { AES } from "crypto-js";
 
 export class PrivateKeyService {
   static decryptData = async (key: CryptoKey, encryptedData: string) => {
-    const r = await crypto.subtle.decrypt({ name: "RSA-OAEP" }, key, base64ToArrayBuffer(encryptedData));
+    const r = await crypto.subtle.decrypt({ name: "RSA-OAEP" }, key, str2ab(encryptedData));
     return ab2str(r);
   };
 

--- a/webui/src/services/publicKeyService.ts
+++ b/webui/src/services/publicKeyService.ts
@@ -1,10 +1,5 @@
 import { ab2str, str2ab } from "@/util/converter";
 
-const getMessageEncoding = (string: string) => {
-  let enc = new TextEncoder();
-  return enc.encode(string);
-};
-
 export const importPublicKey = async (pem: string) => {
   const pemHeader = "-----BEGIN PUBLIC KEY-----";
   const pemFooter = "-----END PUBLIC KEY-----";
@@ -28,7 +23,7 @@ export const encryptData = async (data: string, publicKey: CryptoKey) => {
         name: "RSA-OAEP",
       },
       publicKey,
-      getMessageEncoding(data)
+      str2ab(data)
     )
   );
 

--- a/webui/src/util/converter.ts
+++ b/webui/src/util/converter.ts
@@ -1,22 +1,12 @@
-export const ab2str = (buf: any) => {
+export const ab2str = (buf: ArrayBuffer) => {
   return String.fromCharCode.apply(null, Array.from(new Uint8Array(buf)));
 };
 
-// from https://developers.google.com/web/updates/2012/06/How-to-convert-ArrayBuffer-to-and-from-String
-export function str2ab(str: string) {
-  const buf = new ArrayBuffer(str.length);
-  const bufView = new Uint8Array(buf);
-  for (let i = 0, strLen = str.length; i < strLen; i++) {
-    bufView[i] = str.charCodeAt(i);
-  }
-  return buf;
-}
-
-export const base64ToArrayBuffer = (base64: string) => {
-  var binaryString = atob(base64);
-  var bytes = new Uint8Array(binaryString.length);
-  for (var i = 0; i < binaryString.length; i++) {
-    bytes[i] = binaryString.charCodeAt(i);
+// https://stackoverflow.com/questions/21797299/how-can-i-convert-a-base64-string-to-arraybuffer
+export const str2ab = (str: string) => {
+  const bytes = new Uint8Array(str.length);
+  for (let i = 0; i < str.length; i++) {
+    bytes[i] = str.charCodeAt(i);
   }
   return bytes.buffer;
 };


### PR DESCRIPTION
Behebt die generelle Textdarstellung mit Umlauten.

<img width="486" height="101" alt="grafik" src="https://github.com/user-attachments/assets/cd796fc1-20d6-458c-9cbd-f6e52f9be57b" />

<img width="861" height="33" alt="grafik" src="https://github.com/user-attachments/assets/fadf2f7b-4b5e-43f7-a0c6-9e48f33d2f03" />



Closing #60 